### PR TITLE
Remove instsys setting from mini iso (boo#1063789)

### DIFF
--- a/KIWIMiniIsoPlugin.pm
+++ b/KIWIMiniIsoPlugin.pm
@@ -140,7 +140,6 @@ sub execute {
     );
 
     $this -> updateInitRDNET("./etc/linuxrc.d/10_repo", "defaultrepo=$repoloc\n");
-    $this -> updateInitRDNET("./etc/linuxrc.d/16_instsys", "instsys=disk:boot/___INITRD_ARCH___/root\n");
 
     my @gfxbootfiles;
     find(


### PR DESCRIPTION
On the openSUSE mini iso the instsys is not actually on the medium.
So the parameter that makes linuxrc try to load it locally doesn't
work.