### PR TITLE
do not change the default install method in gfxboot.cfg (bsc#1171018)

### DIFF
--- a/KIWIMiniIsoPlugin.pm
+++ b/KIWIMiniIsoPlugin.pm
@@ -112,7 +112,7 @@ sub execute {
             "<REPO_LOCATION> is unset, boot protocol will be set to 'slp'!"
         );
     } else {
-        if ($repoloc =~ m{^http://([^/]+)/(.+)}x) {
+        if ($repoloc =~ m{^https?://([^/]+)/(.+)}x) {
             ($srv, $path) = ($1, $2);
         }
         if(not defined($srv) or not defined($path)) {
@@ -198,13 +198,8 @@ sub updateGraphicsBootConfig {
                 $ihp = $i;
             }
         }
-        if(!$repoloc) {
-            if($install == -1) {
-                push @lines, "install=slp";
-            } else {
-                $lines[$install] =~ s{^install.*}{install=slp}x;
-            }
-        } elsif($srv) {
+        if($srv) {
+            # store the repo location but don't change the default install method
             if($ihs == -1) {
                 push @lines, "install.http.server=$srv";
             } else {
@@ -214,11 +209,6 @@ sub updateGraphicsBootConfig {
                 push @lines, "install.http.path=$path";
             } else {
                 $lines[$ihp] =~ s{^(install.http.path).*}{$1=$path}x;
-            }
-            if($install == -1) {
-                push @lines, "install=http";
-            } else {
-                $lines[$install] =~ s{^install.*}{install=http}x;
             }
         }
         unlink $cfg;


### PR DESCRIPTION
## Issue

The installation repo location is stored in the initrd and also in gfxboot.cfg. Only one location should be used (the initrd).

This is part of an effort to get `$releasever` in URLs working during installation.

## See also

- https://bugzilla.suse.com/show_bug.cgi?id=1171018
- https://github.com/openSUSE/gfxboot/pull/48

## Implementation

- don't change the install method, just fill out the server & path components in case the user wants to switch.
- don't set `install=slp` if there's no repo
- accept also https

Note that the repo location is already stored in the initrd in the skelcd-installer-net-* packages.